### PR TITLE
[fix] ErrorHandler & actionLogin

### DIFF
--- a/api/components/ErrorHandler.php
+++ b/api/components/ErrorHandler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace api\components;
+
+class ErrorHandler extends \common\components\ErrorHandler
+{
+    public $errorAction = 'site/error';
+}

--- a/api/config/main.php
+++ b/api/config/main.php
@@ -39,15 +39,12 @@ return [
             ],
         ],
         'errorHandler' => [
-            'class' => common\components\ErrorHandler::className(),
+            'class' => api\components\ErrorHandler::className(),
         ],
         'urlManager'   => [
             // to improve the security
             'enableStrictParsing' => true
         ],
-        'response' => [
-            'format' => yii\web\Response::FORMAT_JSON
-        ]
     ],
     'params'              => $params,
 ];

--- a/api/controllers/SiteController.php
+++ b/api/controllers/SiteController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace api\controllers;
+
+use yii\rest\Controller;
+
+/**
+ * Site controller.
+ */
+class SiteController extends Controller
+{
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+
+        $behaviors['authenticator']['except'] = [
+            'error',
+        ];
+
+        return $behaviors;
+    }
+
+    public function actionError()
+    {
+        $exception = \Yii::$app->errorHandler->exception;
+
+        if ($exception !== null) {
+            return [
+                'name'   => $exception->getName(),
+                'status' => $exception->statusCode,
+            ];
+        }
+    }
+}

--- a/api/forms/LoginForm.php
+++ b/api/forms/LoginForm.php
@@ -54,4 +54,20 @@ class LoginForm extends \common\forms\LoginForm
         }
         return false;
     }
+
+    /**
+     * This class permits its instance to get the login column.
+     *
+     * @author Muhammad Yahya Muhaimin <myahyamuhaimin@yahoo.com>
+     */
+    public function getLoginColumn()
+    {
+        try {
+            $loginColumn = parent::getLoginColumn();
+        } catch (InvalidConfigException $e) {
+            return $e->getMessage();
+        }
+
+        return $loginColumn;
+    }
 }

--- a/api/modules/v1/controllers/AuthController.php
+++ b/api/modules/v1/controllers/AuthController.php
@@ -98,14 +98,6 @@ class AuthController extends Controller
             throw new HttpException(400, $e->getMessage(), ApiCode::DEVICE_IDENTIFIER_NOT_FOUND);
         }
 
-        $loginByEmail = \Yii::$app->params['loginByEmail'];
-
-        if ($loginByEmail) {
-            $loginForm->setScenario(LoginForm::SCENARIO_SUBMIT_LOGIN_EMAIL);
-        } else {
-            $loginForm->setScenario(LoginForm::SCENARIO_SUBMIT_LOGIN_USERNAME);
-        }
-
         $loginForm->load(\Yii::$app->request->post(), 'User');
 
         /*
@@ -117,7 +109,20 @@ class AuthController extends Controller
              */
             $user = \Yii::$app->user->getIdentity();
 
-            $msgLoginBy = $loginByEmail ? 'email ' . $user->email : 'username ' . $user->username;
+            $msgLoginBy = '';
+            $loginColumn = $loginForm->getLoginColumn();
+
+            switch ($loginColumn) {
+                case 'username':
+                    $msgLoginBy = 'username ' . $user->username;
+                    break;
+                case 'email':
+                    $msgLoginBy = 'email ' . $user->email;
+                    break;
+                default:
+                    $msgLoginBy = $loginColumn;
+                    break;
+            }
 
             return [
                 'name'    => 'Success',
@@ -226,7 +231,6 @@ class AuthController extends Controller
 
         // this will catch POST request
         if (\Yii::$app->request->isPost) {
-
             $passwordForm->load(\Yii::$app->request->post(), 'User');
 
             if ($passwordForm->validate() && $passwordForm->resetPassword()) {


### PR DESCRIPTION
Tentang format response untuk "Not Found 404" yang harus menyesuaikan dengan header `Accept` dari client app, prosedurnya:
1. Kita harus menimpa atribut `$errorAction` pada class `yii\web\ErrorHandler`.
2. Error action yang dituju tersebut harus berada di dalam Controller yang mengandung `yii\filters\ContentNegotiator`.
3. Jika menggunakan `yii\rest\Controller`, error action tersebut harus dikecualikan dari `['authenticator']`.
4. Jika menggunakan `yii\web\Controller`, tidak ada bawaan `['contentNegotiator']`nya, jadi wajib ditambahkan secara manual.
5. Karena kita menimpa menimpa error action, maka konten response-nya harus kita atur sendiri (sebaiknya berupa array).